### PR TITLE
Linux and c++17 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ cmake_install.cmake
 CMakeCache.txt
 Makefile
 **/*.dir/
-cmake-build-*/
+cmake-build*/
 
 # Compiled output
 ingredients/libingredients.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ if(MSVC)
   add_definitions(/DNOMINMAX)
 endif()
 
+if(UNIX)
+    message(STATUS "Running Linux compiling. Options [GLVND] for modern OpenGL or [LEGACY] for historical OpenGl.")
+    message(STATUS "Setting GLVND option.")
+    set(OpenGL_GL_PREFERENCE GLVND)
+endif()
+
 find_package( glm CONFIG REQUIRED )
 find_package( glfw3 CONFIG REQUIRED )
 find_package( OpenGL REQUIRED )

--- a/ingredients/random.h
+++ b/ingredients/random.h
@@ -2,6 +2,8 @@
 #define GLSLCOOKBOOK_RANDOM_H
 
 #include <random>
+// contains new std::shuffle definition
+#include <algorithm>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
@@ -22,10 +24,8 @@ public:
     }
 
     static void shuffle(std::vector<GLfloat> & v) {
-        std::random_device rd;
-        std::mt19937 g(rd());
-
-        std::shuffle(v.begin(), v.end(), g);
+		auto rng = std::default_random_engine {};
+		std::shuffle(v.begin(), v.end(), rng);
     }
 
 	glm::vec3 uniformHemisphere() {


### PR DESCRIPTION
The gitignore file actually ignores the cmake directory. The CMake file now defaults to modern OpenGL on Unix machines. Before this fix CMake would tell you that 2 versions were available, but it is not clear which one is being used. The random.h file now uses correct C++17 default random number generator. Before this fix C++17 would not compile because the definition of std::shuffle no longer exists. The updated code uses a version of std::shuffle that does exist.
This has been tested and solved on Ubuntu 18.04 LTS with GCC 9.x.x and CMake 3.15.2.