### PR TITLE
Fix `target_link_libraries` for `ingredients` for glm.

### DIFF
--- a/ingredients/CMakeLists.txt
+++ b/ingredients/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(${target} STATIC ${ingredients_SOURCES})
 
 target_include_directories(${target} PUBLIC glad/include)
 
-target_link_libraries(${target} PUBLIC glm)
+target_link_libraries(${target} PUBLIC glm::glm)
 
 if( UNIX AND NOT APPLE )
     target_link_libraries(${target} PUBLIC ${CMAKE_DL_LIBS})


### PR DESCRIPTION
Resolved issues with `glm` during linking by changing `glm` to `glm::glm`, per the [docs](https://github.com/g-truc/glm/blob/master/manual.md#-15-finding-glm-with-cmake).

`glm` installed from source just prior to this change.

Ubuntu 22.04.